### PR TITLE
fixed api name issue for Lightning

### DIFF
--- a/app/js/apiname.js
+++ b/app/js/apiname.js
@@ -19,14 +19,14 @@ DeveloperNameInputElement.setName = function(d, c, g) {
 BfsApiName.init = function() {
   if ($('input#MasterLabel').size() === 0 ||
       ($('input#DeveloperName').size() === 0 &&
-        $('input#Name').size() === 0) || 
+        $('input#Name').size() === 0) ||
       ($('input#DeveloperName').size() > 0 &&
         $('input#DeveloperName').is(':disabled')) ||
       ($('input#Name').size() > 0 &&
         $('input#Name').is(':disabled'))) {
     return;
   }
-  
+
   $('input#MasterLabel').blur(function() {
     if ($('input#DeveloperName').size() === 1) {
       DeveloperNameInputElement.setName(this, document.getElementById('DeveloperName'), 'Field1');

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -67,9 +67,11 @@
         "https://*.force.com/*101*",
         "https://*.cloudforce.com/*101*"
       ],
-      "js": [
+      "js":[
+        "js/jquery.min.js",
         "js/apiname.js"
-      ]
+      ],
+      "all_frames": true
     },
     {
       "matches": [


### PR DESCRIPTION
In Salesforce Lightning the Object/Field API Name feature was not working. This was due to Lightning using an iframe now to load the New Custom Field page. By updating the manifest.json file to load the jquery and apiname.js files for all frames, this feature now works in Lightning and Classic.